### PR TITLE
Update boost + content revealer shortcode

### DIFF
--- a/blocks/boost/block.json
+++ b/blocks/boost/block.json
@@ -22,6 +22,26 @@
 		"variant": {
 			"type": "string",
 			"default": "colorized"
+		},
+		"display-mode": {
+			"type": "string",
+			"default": "with-text"
+		},
+		"size": {
+			"type": "string",
+			"default": "md"
+		},
+		"mobile-display-mode": {
+			"type": "string",
+			"default": "inherit"
+		},
+		"mobile-float-location": {
+			"type": "string",
+			"default": "inherit"
+		},
+		"mobile-size": {
+			"type": "string",
+			"default": "inherit"
 		}
 	},
 	"editorScript": "file:./index.js"

--- a/blocks/boost/edit.js
+++ b/blocks/boost/edit.js
@@ -21,6 +21,7 @@ const FLOAT_LOCATION_OPTIONS = [
 	{ label: 'top-right', value: 'top-right' },
 	{ label: 'bottom-left', value: 'bottom-left' },
 	{ label: 'bottom-center', value: 'bottom-center' },
+	{ label: 'bottom-right', value: 'bottom-right' },
 ];
 
 const VARIANT_OPTIONS = [
@@ -29,84 +30,160 @@ const VARIANT_OPTIONS = [
 	{ label: 'dark', value: 'dark' },
 ];
 
-export default function Edit( props ) {
+const DISPLAY_MODE_OPTIONS = [
+	{ label: 'with-text', value: 'with-text' },
+	{ label: 'icon-only', value: 'icon-only' },
+];
+
+const SIZE_OPTIONS = [
+	{ label: 'small', value: 'sm' },
+	{ label: 'medium', value: 'md' },
+];
+
+const MOBILE_FLOAT_LOCATION_OPTIONS = [
+	{ label: 'inherit', value: 'inherit' },
+	...FLOAT_LOCATION_OPTIONS,
+];
+
+const MOBILE_DISPLAY_MODE = [
+	{ label: 'inherit', value: 'inherit' },
+	...DISPLAY_MODE_OPTIONS,
+];
+
+const MOBILE_SIZE = [{ label: 'inherit', value: 'inherit' }, ...SIZE_OPTIONS];
+
+export default function Edit(props) {
 	// https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#block-wrapper-props
 	const blockProps = useBlockProps();
 
 	const { attributes } = props;
 
-	const setAttribute = ( key, value ) => {
-		props.setAttributes( { [ key ]: value } );
+	const setAttribute = (key, value) => {
+		props.setAttributes({ [key]: value });
 	};
 
-	useScript( 'https://components.getmash.com/boost/boost.js' );
+	useScript('https://widgets.getmash.com/boost/boost.js');
 
 	return (
-		<div className={ props.className } { ...blockProps }>
+		<div className={props.className} {...blockProps}>
 			<InspectorControls key="inspector">
 				<PanelBody title="Mash Boost Options">
 					<PanelRow>
 						<SelectControl
 							label="Variant"
-							value={ attributes.variant }
-							options={ VARIANT_OPTIONS }
-							onChange={ ( value ) =>
-								setAttribute( 'variant', value )
-							}
+							value={attributes.variant}
+							options={VARIANT_OPTIONS}
+							onChange={(value) => setAttribute('variant', value)}
 						/>
 					</PanelRow>
 					<PanelRow>
 						<SelectControl
 							label="Icon"
-							value={ attributes.icon }
-							options={ ICON_OPTIONS }
-							onChange={ ( value ) =>
-								setAttribute( 'icon', value )
-							}
+							value={attributes.icon}
+							options={ICON_OPTIONS}
+							onChange={(value) => setAttribute('icon', value)}
 						/>
 					</PanelRow>
 					<PanelRow>
 						<SelectControl
 							label="Layout"
-							value={ attributes[ 'layout-mode' ] }
-							options={ LAYOUT_OPTIONS }
-							onChange={ ( value ) =>
-								setAttribute( 'layout-mode', value )
+							value={attributes['layout-mode']}
+							options={LAYOUT_OPTIONS}
+							onChange={(value) =>
+								setAttribute('layout-mode', value)
 							}
 						/>
 					</PanelRow>
-					{ attributes[ 'layout-mode' ] === 'float' && (
+					{attributes['layout-mode'] === 'float' && (
 						<PanelRow>
 							<SelectControl
 								label="Location"
-								value={ attributes[ 'float-location' ] }
-								options={ FLOAT_LOCATION_OPTIONS }
-								onChange={ ( value ) =>
-									setAttribute( 'float-location', value )
+								value={attributes['float-location']}
+								options={FLOAT_LOCATION_OPTIONS}
+								onChange={(value) =>
+									setAttribute('float-location', value)
 								}
 							/>
 						</PanelRow>
-					) }
+					)}
+					<PanelRow>
+						<SelectControl
+							label="Display Mode"
+							value={attributes['display-mode']}
+							options={DISPLAY_MODE_OPTIONS}
+							onChange={(value) =>
+								setAttribute('display-mode', value)
+							}
+						/>
+					</PanelRow>
+					<PanelRow>
+						<SelectControl
+							label="Size"
+							value={attributes['size']}
+							options={SIZE_OPTIONS}
+							onChange={(value) => setAttribute('size', value)}
+						/>
+					</PanelRow>
+
+					<PanelRow>
+						<div>
+							A value of "inherit" will match the value from
+							desktop configuration above.
+						</div>
+					</PanelRow>
+
+					<PanelRow>
+						<SelectControl
+							label="Mobile Display Mode"
+							value={attributes['mobile-display-mode']}
+							options={MOBILE_DISPLAY_MODE}
+							onChange={(value) =>
+								setAttribute('mobile-display-mode', value)
+							}
+						/>
+					</PanelRow>
+					{attributes['layout-mode'] === 'float' && (
+						<PanelRow>
+							<SelectControl
+								label="Mobile Float Location"
+								value={attributes['mobile-float-location']}
+								options={MOBILE_FLOAT_LOCATION_OPTIONS}
+								onChange={(value) =>
+									setAttribute('mobile-float-location', value)
+								}
+							/>
+						</PanelRow>
+					)}
+					<PanelRow>
+						<SelectControl
+							label="Mobile Size"
+							value={attributes['mobile-size']}
+							options={MOBILE_SIZE}
+							onChange={(value) =>
+								setAttribute('mobile-size', value)
+							}
+						/>
+					</PanelRow>
 				</PanelBody>
 			</InspectorControls>
 
 			<ServerSideRender
 				block="mash/boost-button"
-				attributes={ attributes }
+				attributes={attributes}
 			/>
 
-			{ attributes[ 'layout-mode' ] === 'float' && (
+			{attributes['layout-mode'] === 'float' && (
 				<div
-					style={ {
+					style={{
 						backgroundColor: 'rgba(0,0,0,0.1)',
 						fontSize: '1rem',
 						padding: '1rem 0.75rem',
-					} }
+					}}
 				>
 					Mash boost button block placeholder. Button is in float
 					mode. Click to edit block.
 				</div>
-			) }
+			)}
 		</div>
 	);
 }

--- a/blocks/paywall/block.json
+++ b/blocks/paywall/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://json.schemastore.org/block.json",
 	"apiVersion": 2,
 	"name": "mash/paywall",
-	"title": "Mash Paywall",
+	"title": "Mash Content Revealer",
 	"textdomain": "mash-blocks",
 	"icon": "superhero",
 	"category": "mash-blocks",
@@ -17,6 +17,22 @@
 		"subtitle": {
 			"type": "string",
 			"default": "Setting a budget will auto unlock content."
+		},
+		"button-label": {
+			"type": "string",
+			"default": "Unlock Content"
+		},
+		"button-variant": {
+			"type": "string",
+			"default": "solid"
+		},
+		"button-size": {
+			"type": "string",
+			"default": "md"
+		},
+		"loading-indicator-size": {
+			"type": "string",
+			"default": "14"
 		}
 	},
 	"editorScript": "file:./index.js"

--- a/blocks/paywall/edit.js
+++ b/blocks/paywall/edit.js
@@ -8,10 +8,11 @@ import {
 import {
 	PanelBody,
 	PanelRow,
+	SelectControl,
 	TextControl,
 	TextareaControl,
 	ToggleControl,
-	Button,
+	__experimentalText as Text,
 } from '@wordpress/components';
 import ServerSideRender from '@wordpress/server-side-render';
 
@@ -21,6 +22,17 @@ const PAY_PER_USE_URL = 'https://wallet.getmash.com/earn/pay-per-use';
 // Based on the regex here: https://ihateregex.io/expr/uuid/
 const RESOURCE_ID_REGEX =
 	/^[0-9a-f]{8}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{12}$/i;
+
+const VARIANT_OPTIONS = [
+	{ label: 'solid', value: 'solid' },
+	{ label: 'outlined', value: 'outlined' },
+];
+
+const SIZE_OPTIONS = [
+	{ label: 'small', value: 'sm' },
+	{ label: 'medium', value: 'md' },
+	{ label: 'large', value: 'lg' },
+];
 
 export default function Edit(props) {
 	// https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#block-wrapper-props
@@ -38,13 +50,33 @@ export default function Edit(props) {
 		setInvalidResourceID(!validResourceID);
 	};
 
+	useEffect(() => {
+		const style = window.document.createElement('style');
+		style.innerHTML = `
+	:root {
+		--mash-primary-color-h: 0;
+		--mash-primary-color-s: 0%;
+		--mash-primary-color-l: 0%;
+		--mash-primary-color: #000;
+		--mash-font-family: sans-serif;
+	}  
+	`;
+		window.document.head.appendChild(style);
+
+		const link = window.document.createElement('link');
+		link.rel = 'stylesheet';
+		link.href = `https://widgets.getmash.com/theme/theme.css`;
+
+		window.document.head.appendChild(link);
+	}, []);
+
 	// Set the validity of the resource ID when the component first mounts
 	useEffect(() => {
 		updateResourceIDValidity(attributes['resource']);
 	}, []);
 
 	// Pull in the web component's script
-	useScript('https://components.getmash.com/content/paywall.js');
+	useScript('https://widgets.getmash.com/content/content-revealer.js');
 
 	return (
 		<div className={props.className} {...blockProps}>
@@ -52,13 +84,13 @@ export default function Edit(props) {
 				<PanelBody title="Editor Options">
 					<PanelRow>
 						<ToggleControl
-							label="Preview paywall"
+							label="Preview content revealer"
 							checked={previewPaywall}
 							onChange={(value) => setPreviewPaywall(value)}
 						/>
 					</PanelRow>
 				</PanelBody>
-				<PanelBody title="Mash Paywall Options">
+				<PanelBody title="Mash Content Revealer Options">
 					<PanelRow>
 						<TextControl
 							label="Mash Price Category Tag"
@@ -89,6 +121,63 @@ export default function Edit(props) {
 							}
 						/>
 					</PanelRow>
+					<PanelRow>
+						<TextControl
+							label="Button Label"
+							help="The subtitle to display when the paywall is visible."
+							value={attributes['button-label']}
+							onChange={(value) =>
+								setAttribute('button-label', value)
+							}
+						/>
+					</PanelRow>
+
+					<PanelRow>
+						<Text>
+							Button color and font family can be configured in
+							the Mash Platform dashboard{' '}
+							<a
+								href="https://wallet.getmash.com/earn/customize"
+								target="_blank"
+							>
+								here.
+							</a>
+						</Text>
+					</PanelRow>
+
+					<PanelRow></PanelRow>
+
+					<PanelRow>
+						<SelectControl
+							label="Button Variant"
+							value={attributes['button-variant']}
+							options={VARIANT_OPTIONS}
+							onChange={(value) =>
+								setAttribute('button-variant', value)
+							}
+						/>
+					</PanelRow>
+
+					<PanelRow>
+						<SelectControl
+							label="Button Size"
+							value={attributes['button-size']}
+							options={SIZE_OPTIONS}
+							onChange={(value) =>
+								setAttribute('button-size', value)
+							}
+						/>
+					</PanelRow>
+					<PanelRow>
+						<TextControl
+							type="number"
+							label="Loading Indicator Size"
+							value={attributes['loading-indicator-size']}
+							onChange={(value) =>
+								setAttribute('loading-indicator-size', value)
+							}
+						/>
+					</PanelRow>
 				</PanelBody>
 			</InspectorControls>
 
@@ -100,8 +189,8 @@ export default function Edit(props) {
 						<i>Mash Price Category Tag</i> may not be set yet, or
 						may be in the incorrect format. Please update the
 						corresponding field in this block's{' '}
-						<i>Mash Paywall Options</i> to match the desired price
-						category tag provided within the{' '}
+						<i>Mash Content Revealer Options</i> to match the
+						desired price category tag provided within the{' '}
 						<a href={PAY_PER_USE_URL}>
 							"Pay-Per-Use" section of the Mash web app
 						</a>

--- a/includes/mash_settings.php
+++ b/includes/mash_settings.php
@@ -15,7 +15,7 @@ $mash_posts       = get_posts();
       <img src="<?php echo plugin_dir_url( __FILE__ ) . "../images/mash-text-logo.svg" ?>"/>
     </div>
     <div class="mash-earner-app-link">   <?php 
-        echo  ($settings_earner_id == '<earner_id>' ? '<a class="mash-button cta" href="https://wallet.getmash.com/earn" target="_blank">New? Create a New Account</a>' : '<a class="mash-button secondary" href="https://wallet.getmash.com/earn" target="_blank">Open Earn With Mash App</a>');
+        echo  ($settings_earner_id == '' ? '<a class="mash-button cta" href="https://wallet.getmash.com/earn" target="_blank">New? Create a New Account</a>' : '<a class="mash-button secondary" href="https://wallet.getmash.com/earn" target="_blank">Open Earn With Mash App</a>');
       ?>
     </div>
   </div>
@@ -54,7 +54,7 @@ $mash_posts       = get_posts();
               class="mash-input" 
               placeholder="Ex. b34dbb03-44cf-4dfc-a062-5ee7868f9d16" 
               name="data[earner_id]" 
-              value="<?php echo ($settings_earner_id == '<earner_id>' ? '' : esc_attr($settings_earner_id)); ?>" 
+              value="<?php echo (esc_attr($settings_earner_id)); ?>" 
               pattern="[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}" />
           </div>
           <button type="submit" class="mash-button save-button">Save</button>

--- a/mash.php
+++ b/mash.php
@@ -3,7 +3,7 @@
 * Plugin Name: Mash - Monetize, Earn, and Grow your Experiences w/ Bitcoin Lightning
 * Plugin URI: https://github.com/getmash/wordpress-mash-plugin
 * Description: Setup and configure a Mash Wallet on your wordpress site. Earn more in an entirely new and interactive way!
-* Version: 2.0.1
+* Version: 2.1.0
 * Author: Mash
 * Author URI: https://www.getmash.com/
 **/

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: getmash
 Tags: bitcoin, lightning, creators, mash, monetize, revenue, interaction, writers, bloggers, payments, developers, earn 
 Requires at least: 6.0.0
 Tested up to: 6.0.2
-Stable tag: 2.0.1
+Stable tag: 2.1.0
 Requires PHP: 7.3.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -88,6 +88,13 @@ Simply deactivate and delete the plugin.
 4. Mash Wallet
   
 == Changelog ==
+
+= 2.1.0 =
+* MODIFIED: Shortcodes to use updated web components
+* MODIFIED: Renamed Mash Paywall block to Mash Content Revealer
+* ADDED: mash_content_revealer shortcode, deprecated mash_paywall
+* ADDED: Additional configuration options for Mash Boost shortcode
+* ADDED: Additional configuration options for Mash Content Revealer
 
 = 2.0.1 =
 * FIXED: Dashboard menu icon for Mash shows up now.

--- a/shortcodes/mash_boost.php
+++ b/shortcodes/mash_boost.php
@@ -11,16 +11,36 @@ function mash_boost_button_shortcode( $atts = array(), $content = null, $tag = '
       'icon' => 'lightning',
       'layout-mode' => 'float',
       'float-location' => 'top-center',
-      'variant' => 'colorized'
+      'variant' => 'colorized',
+      'display-mode' => 'with-text',
+      'size' => 'md',
+      'mobile-display-mode' => 'inherit',
+      'mobile-float-location' => 'inherit',
+      'mobile-size' => 'inherit'
     ), $atts, $tag
   );
 
-  $output = '<script defer src="https://components.getmash.com/boost/boost.js"></script>';
+  $output = '<script defer src="https://widgets.getmash.com/boost/boost.js"></script>';
   $output .= '<mash-boost-button ';
   $output .= 'icon="' . esc_attr( $boost_atts['icon'] ) . '" ';
   $output .= 'layout-mode="' . esc_attr( $boost_atts['layout-mode'] ) . '" ';
   $output .= 'variant="' . esc_attr( $boost_atts['variant'] ) . '" ';
+  $output .= 'display-mode="' . esc_attr( $boost_atts['display-mode'] ) . '" ';
   $output .= 'float-location="' . esc_attr( $boost_atts['float-location'] ) . '" ';
+  $output .= 'size="' . esc_attr( $boost_atts['size'] ) . '" ';
+
+  if ($boost_atts['mobile-display-mode'] != 'inherit') {
+    $output .= 'mobile-display-mode="' . esc_attr( $boost_atts['mobile-display-mode'] ) . '" ';
+  }
+
+  if ($boost_atts['mobile-float-location'] != 'inherit') {
+    $output .= 'mobile-float-location="' . esc_attr( $boost_atts['mobile-float-location'] ) . '" ';
+  }
+
+  if ($boost_atts['mobile-size'] != 'inherit') {
+    $output .= 'mobile-size="' . esc_attr( $boost_atts['mobile-size'] ) . '" ';
+  }
+
   $output .= '></mash-boost-button>';
 
   return $output;

--- a/shortcodes/mash_paywall.php
+++ b/shortcodes/mash_paywall.php
@@ -22,7 +22,7 @@ function mash_paywall_shortcode( $atts = array(), $content = null, $tag = '' ) {
 
   if (!preg_match($resource_regex, $paywall_atts['resource'])) {
     // Render an error if the resource attribute is invalid
-    return '<p style="color: red">[mash_paywall error: Invalid configuration (resource ID must be specified in UUID format). Please contact website owner.]</p>';
+    return '<p style="color: red">[mash_content_revealer error: Invalid configuration ' . esc_attr( $paywall_atts['resource'] ) . ' (resource ID must be specified in UUID format). Please contact website owner.]</p>';
   }
   
   $output = '<div> ';

--- a/shortcodes/mash_paywall.php
+++ b/shortcodes/mash_paywall.php
@@ -13,6 +13,10 @@ function mash_paywall_shortcode( $atts = array(), $content = null, $tag = '' ) {
       'resource' => '',
       'title' => 'Enjoy some free content, then pay-to-enjoy',
       'subtitle' => 'Setting a budget will auto unlock content.',
+      'button-label' => 'Unlock Content',
+      'button-variant' => 'solid',
+      'button-size' => 'md',
+      'loading-indicator-size' => '14',
     ), $atts, $tag
   );
 
@@ -22,19 +26,27 @@ function mash_paywall_shortcode( $atts = array(), $content = null, $tag = '' ) {
   }
   
   $output = '<div> ';
-  $output .= '<script defer src="https://components.getmash.com/content/paywall.js"></script>';
-  $output .= '<mash-paywall ';
+  $output .= '<script defer src="https://widgets.getmash.com/content/content-revealer.js"></script>';
+  $output .= '<mash-content-revealer ';
   // Use the post's name as the web component's key
   $output .= 'key="' . esc_attr( get_post_field( 'post_name', get_post() ) ) . '" ';
   $output .= 'resource="' . esc_attr( $paywall_atts['resource'] ) . '" ';
   $output .= 'title="' . esc_attr( $paywall_atts['title'] ) . '" ';
   $output .= 'subtitle="' . esc_attr( $paywall_atts['subtitle'] ) . '" ';
+  $output .= 'button-label="' . esc_attr( $paywall_atts['button-label'] ) . '" ';
+  $output .= 'button-variant="' . esc_attr( $paywall_atts['button-variant'] ) . '" ';
+  $output .= 'button-size="' . esc_attr( $paywall_atts['button-size'] ) . '" ';
+  $output .= 'loading-indicator-size="' . esc_attr( $paywall_atts['loading-indicator-size'] ) . '" ';
+
   $output .= '>';
   $output .= do_shortcode($content);
-  $output .= '</mash-paywall> ';
+  $output .= '</mash-content-revealer> ';
   $output .= '</div>' ;
 
   return $output;
 }
 
+add_shortcode('mash_content_revealer', 'mash_paywall_shortcode');
+
+// Include deprecated version
 add_shortcode('mash_paywall', 'mash_paywall_shortcode');


### PR DESCRIPTION
## Overview

- Updated shortcode script version to leverage new `widgets` hosting environment
- Updated `mash-paywall` to use `mash-content-revealer`. `block.json` attribute is still called `mash/paywall` to be backwards compatible in editors. If this is changed, then all active implementations will change to `Unsupported`